### PR TITLE
Adding "additionalInformatonService"

### DIFF
--- a/web/src/app/modules/views/side/modules/links-actions/components/links-actions.component.ts
+++ b/web/src/app/modules/views/side/modules/links-actions/components/links-actions.component.ts
@@ -20,6 +20,7 @@ export class LinksActions {
     public _model: IContainer;
     public _contents: IContainer[];
     public _testSpecifications: TestSpecification[];
+    public _additionalInformationService: TestSpecification;
     public descriptionVisible: boolean;
 
     constructor(private additionalInformationService: AdditionalInformationService) { }


### PR DESCRIPTION
Refactored the getter for in line 41 and line 44 by declaring the "additionalInformationService" as public in line 23 so that it actually refers to the property "_testSpecification" .